### PR TITLE
added custom client route to query the hub_id

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,28 @@
+{
+	"hubsarray": 
+	[
+		{
+			"hub_id": "2MCVA2f", 
+			"urls":"https://colinfizgig.github.io/Custom-Hubs-Components/components/camera-cube-env.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/slideconfig.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/slideshow-template.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/hubs-slide-show.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/interactable-ball.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/presence-customcmd-setup.js"
+		},
+		{
+			"hub_id": "8T88rLN",
+			"urls":"https://colinfizgig.github.io/Custom-Hubs-Components/components/camera-cube-env.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/pdfshow-template.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/hubs-pdf-show.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/interactable-ball.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/presence-customcmd-setup.js"},
+		{
+			"hub_id": "5HsuTZ2",
+			"urls":"https://colinfizgig.github.io/Custom-Hubs-Components/components/slideconfig.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/hubs-slide-show.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/slideshow-template.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/presence-customcmd-setup.js"
+		},
+		{
+			"hub_id": "kBquF8A",
+			"urls":"https://colinfizgig.github.io/Custom-Hubs-Components/components/camera-cube-env.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/interactable-ball.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/presence-customcmd-setup.js"
+		},
+		{
+			"hub_id": "DVeQzPW",
+			"urls":"https://colinfizgig.github.io/Custom-Hubs-Components/components/camera-cube-env.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/interactable-ball.js,https://colinfizgig.github.io/Custom-Hubs-Components/components/presence-customcmd-setup.js"
+		},
+		{
+			"hub_id": "xr6jnY2",
+			"urls":"https://colinfizgig.github.io/Custom-Hubs-Components/components/camera-cube-env.js,https://colinfizgig.github.io/aframe_Components/asteroids/js/agame.js,https://colinfizgig.github.io/aframe_Components/asteroids/js/AGameKeymapping.js,https://cdn.rawgit.com/donmccurdy/aframe-extras/v4.2.0/dist/aframe-extras.min.js,https://colinfizgig.github.io/aframe_Components/components/aframe-thumb-controls-component.min.js"
+		}
+	]
+}

--- a/index.js
+++ b/index.js
@@ -3,8 +3,25 @@ const http = require("http");
 const https = require("https");
 const socketIO = require("socket.io");
 const express = require("express");
+const cors = require('cors');
+const fetch = require('node-fetch');
+
+//load the config files which contains our hub_ids and their urls
+const configUrl = 'https://colinfizgig.github.io/Custom-Hubs-Components/top-level-main-server/config.json';
+
+let settings = { method: "Get" };
+//temp variable for config
+let config = {};
+// promise to load config
+const configPromise = fetch(configUrl, settings)
+    .then(res => res.json())
+    .then((json) => {
+		config = json;
+		return(json);
+    });
 
 const app = express();
+app.use(cors());
 
 app.use(express.static("public"));
 
@@ -16,6 +33,33 @@ app.get(
     );
   }
 );
+
+//route for custom client to check hub_id
+//hub_id is passed as a query param from the script in hub.js
+// the url to hit his route should be something like...
+// https://<domain for this server>/injectScripts?hubid=<hub_id>
+
+app.get(
+	"/injectScripts",
+	async (req, res) => {
+			let result = {}
+			try{ result.success = true;}
+			catch(e){ result.success = false;}
+			finally{
+				var myHub = req.query.hubid;
+				var myUrls = "";
+				for (var hubObj of config.hubsarray){
+					if(hubObj.hub_id == myHub){
+						myUrls = hubObj.urls;
+						res.send(myUrls);
+						break;
+					}
+				}
+				if(myUrls == ""){
+					res.send("noUrls");
+				}
+			}
+	});
 
 /////////
 const privKeyFileName = "/etc/letsencrypt/live/aelatgt.net/privkey.pem";

--- a/package-lock.json
+++ b/package-lock.json
@@ -677,6 +677,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cron": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/cron/-/cron-1.8.2.tgz",
@@ -1459,6 +1468,11 @@
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1482,6 +1496,11 @@
           "dev": true
         }
       }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "top level node server",
   "main": "index.js",
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "fs": "0.0.1-security",
     "http": "0.0.0",
     "https": "^1.0.0",
+    "node-fetch": "^2.6.1",
     "socket.io": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
changed the route to pull from hosted config so it will be easier to modify the config file without having to access aws.  requires cors and node-fetch.

You will want to set up the repository with a ghpages host and change the line

const configUrl = 'https://colinfizgig.github.io/Custom-Hubs-Components/top-level-main-server/config.json';

to point to our aelatgt hosted version of config.json.  The idea is that whoever can add scripts to the custom client can modify the config.json in order to add those scripts to their hub_id.  That way we won't need access to the AWS top-level to make changes.  Eventually we might make a component that can inject the config using Spoke in order to bypass the need for a top-level server.